### PR TITLE
Update useSize.js

### DIFF
--- a/src/19-useSize/useSize.js
+++ b/src/19-useSize/useSize.js
@@ -1,5 +1,4 @@
-import { useState } from "react"
-import { useEffect } from "react/cjs/react.development"
+import { useState, useEffect } from "react"
 
 export default function useSize(ref) {
   const [size, setSize] = useState({})


### PR DESCRIPTION
Hello Kelly, thanks much for such great sharing. I notice this line of import in custom `useSize` hook.

`import { useEffect } from "react/cjs/react.development"`

Is this import intended or just a typo or something. I found in newer react versions, this line of code cast errors in my place.

Could we just use the `useEffect` hook from `react` directly.

Thanks